### PR TITLE
Add VERBOSE to the MANIFEST argument in the unload macro

### DIFF
--- a/macros/unload.sql
+++ b/macros/unload.sql
@@ -65,7 +65,7 @@ where option is
   {{ exceptions.raise_compiler_error("You must provide AWS authorization parameters via 'iam_role' or 'aws_key' and 'aws_secret'.") }}
   {% endif %}
   {% if manifest %}
-  MANIFEST
+  MANIFEST VERBOSE
   {% endif %}
   {% if header %}
   HEADER


### PR DESCRIPTION
## Description & motivation
The current unload macro does not produce a verbose manifest file. Given that this is very useful information for reading into other database environments or data analytics tools and doesn't really come at the expense of much computation adding it as the default nature seems like solid move. If you'd prefer it to be an argument, I can make those changes. 

## Checklist
- [X] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)