### PR TITLE
require v1, bump utils dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,11 @@
+# redshift 0.6.0
+
+This release supports any version (minor and patch) of v1, which means far less need for compatibility releases in the future.
+
+## Under the hood
+- Change `require-dbt-version` to `[">=1.0.0", "<2.0.0"]`
+- Bump dbt-utils dependency
+- Replace `source-paths` with `model-paths`
+
 # redshift v0.5.1
 🚨 This is a compatibility release in preparation for `dbt-core` v1.0.0 (🎉). Projects using this version with `dbt-core` v1.0.x can expect to see a deprecation warning. This will be resolved in the next minor release.

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,9 +2,9 @@ name: 'redshift'
 version: '0.5.0'
 config-version: 2
 
-require-dbt-version: [">=0.17.0", "<1.1.0"]
+require-dbt-version: [">=1.0.0", "<2.0.0"]
 
-source-paths: ["models"]
+model-paths: ["models"]
 macro-paths: ["macros"]
 test-paths: ["tests"]
 

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=0.4.0", "<0.8.0"]
+    version: [">=0.8.0", "<0.9.0"]


### PR DESCRIPTION
## Description & motivation
- Change `require-dbt-version` to `[">=1.0.0", "<2.0.0"]`
- Bump dbt-utils dependency
- Replace `source-paths` with `model-paths`

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)