### PR TITLE
Add support for 'cleanpath' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Macro signature:
                 add_quotes=Boolean,
                 encrypted=Boolean,
                 overwrite=Boolean,
+                cleanpath=Boolean,
                 parallel=Boolean,
                 partition_by=none|List<String>
 ) }}

--- a/macros/unload.sql
+++ b/macros/unload.sql
@@ -20,6 +20,7 @@ where option is
 | NULL [ AS ] 'null-string'
 | ESCAPE
 | ALLOWOVERWRITE
+| CLEANPATH
 | PARALLEL [ { ON | TRUE } | { OFF | FALSE } ]
 | MAXFILESIZE [AS] max-size [ MB | GB ] 
 | REGION [AS] 'aws-region' }
@@ -45,6 +46,7 @@ where option is
                 add_quotes=False,
                 encrypted=False,
                 overwrite=False,
+                cleanpath=False,
                 parallel=False,
                 partition_by=None
                 ) %}
@@ -93,6 +95,9 @@ where option is
   {% if overwrite %}
   ALLOWOVERWRITE
   {% endif %}
+  {% if cleanpath %}
+  CLEANPATH
+  {% endif %}  
   {% if not parallel %}
   PARALLEL OFF
   {% endif %}


### PR DESCRIPTION
Unload command in Redshift supports, among others, the 'cleanup' option, which hasn't been supported by this macro so far. This change is aimed at adding the missing support. 

Note: "cleanpath" cannot be used together with "allowoverwrite"; no check is made in (this version of) the macro to test for their co-presence.

Note 2: the macro was tested locally by placing the edited version in /macros folder and calling `unload_table()` directly, without installing and calling it as a part of the redshift package.
