### PR TITLE
Add flag to skip `compress_table` if running model in incremental mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ These models (default ephemeral) make it possible to inspect tables, columns, co
 
 #### compress_table ([source](macros/compression.sql))
 
-This macro returns the SQL required to auto-compress a table using the results of an `analyze compression` query. All comments, constraints, keys, and indexes are copied to the newly compressed table by this macro. Additionally, sort and dist keys can be provided to override the settings from the source table. By default, a backup table is made which is _not_ deleted. To delete this backup table after a successful copy, use `drop_backup` flag.
+This macro returns the SQL required to auto-compress a table using the results of an `analyze compression` query. All comments, constraints, keys, and indexes are copied to the newly compressed table by this macro. Additionally, sort and dist keys can be provided to override the settings from the source table. By default, a backup table is made which is _not_ deleted. To delete this backup table after a successful copy, use `drop_backup` flag. 
+Note, that this macro will have to rewrite the entire table. The `skip_if_incremental` flag can be used to skip this macro if it is being called in an `is_incremental()` context, e.g. when used as a post-hook on an incremental model.
 
 Macro signature:
 ```
@@ -69,7 +70,8 @@ Macro signature:
                   sort_style=none|compound|interleaved,
                   sort_keys=none|List<String>,
                   dist_style=none|all|even,
-                  dist_key=none|String) }}
+                  dist_key=none|String,
+                  skip_if_incremental=False) }}
 ```
 
 Example usage:

--- a/macros/compression.sql
+++ b/macros/compression.sql
@@ -61,10 +61,14 @@
 
 {%- macro compress_table(schema, table, drop_backup=False,
                          comprows=none, sort_style=none, sort_keys=none,
-                         dist_style=none, dist_key=none) -%}
+                         dist_style=none, dist_key=none, skip_if_incremental=False) -%}
 
   {% if not execute %}
     {{ return(none) }}
+  {% endif %}
+  
+  {% if skip_if_incremental and is_incremental() %}
+    {{ return('') }}
   {% endif %}
 
   {% set recommendation = redshift.find_analyze_recommendations(schema, table, comprows) %}


### PR DESCRIPTION
## Description & motivation
Added a `skip_if_incremental` flag to the `compress_table` macro. This can be useful when running the macro as a post-hook on a large, incremental model where we might not want to re-analyze the compression and rewrite the table on every incremental run.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)