### PR TITLE
add in_place option for compression w/o deep copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,18 @@ These models (default ephemeral) make it possible to inspect tables, columns, co
 
 #### compress_table ([source](macros/compression.sql))
 
-This macro returns the SQL required to auto-compress a table using the results of an `analyze compression` query. All comments, constraints, keys, and indexes are copied to the newly compressed table by this macro. Additionally, sort and dist keys can be provided to override the settings from the source table. By default, a backup table is made which is _not_ deleted. To delete this backup table after a successful copy, use `drop_backup` flag.
+This macro returns the SQL required to auto-compress a table using the results of an `analyze compression` query. 
+
+If `in_place=False` (default behavior), the table is renamed to `{{ table }}__backup` and replaced by a deep copy that utilizes the recommended encodings. All comments, constraints, keys, and indexes are copied to the newly compressed table by this macro. Additionally, sort and dist keys can be provided to override the settings from the source table. By default, the backup table is _not_ deleted; to delete the backup table after a successful copy, use `drop_backup` flag.
+
+If `in_place=True`, columns whose encodings differ from the recommended encoding will be directly updated using the `ALTER TABLE {{ table }} ALTER COLUMN {{ column }} ENCODE {{ encoding }}` command. Since this process does not require a deep copy of the target table, subsequent optional arguments are ignored. 
+
+For guidance on if `in_place` is appropriate, consult [the AWS documentation](https://aws.amazon.com/about-aws/whats-new/2020/10/amazon-redshift-supports-modifying-column-comprression-encodings-to-optimize-storage-utilization-query-performance/) and [release announcement](https://aws.amazon.com/about-aws/whats-new/2020/10/amazon-redshift-supports-modifying-column-comprression-encodings-to-optimize-storage-utilization-query-performance/).
 
 Macro signature:
 ```
 {{ compress_table(schema, table,
+                  in_place=False,
                   drop_backup=False,
                   comprows=none|Integer,
                   sort_style=none|compound|interleaved,

--- a/macros/compression.sql
+++ b/macros/compression.sql
@@ -41,12 +41,11 @@
 
 {%- endmacro %}
 
-{%- macro alter_column_encoding(schema, table, updated_encodings) -%}
+{%- macro alter_column_encodings(schema, table, updated_encodings) -%}
   
   {% for column_name, encoding in updated_encodings.items() %}
       alter table {{ schema }}.{{ table }} alter {{ column_name }} encode {{ encoding }}; 
   {% endfor %}
-  commit;
 
 {% endmacro %}
 
@@ -93,7 +92,7 @@
   {% if in_place %}
       -- only alter the column encodings if at least one column will change to avoid returning an empty query
       {% if updated_encodings %}
-        {{ redshift.alter_column_encoding(schema, table, updated_encodings) }}
+        {{ redshift.alter_column_encodings(schema, table, updated_encodings) }}
       {% endif %}
   {% else %}
     {% set _ = optimized.update({"keys": optimized.get('keys', {}) | default({})}) %}

--- a/macros/compression.sql
+++ b/macros/compression.sql
@@ -18,6 +18,9 @@
 
 {% macro build_optimized_definition(definition, recommendation) -%}
 
+    -- tracks which (if any) of the column encodings will change; used when in_place=True to prevent alter_column_encodings() from returning an empty query
+    {% set updated_encodings = {} %}
+
     {% set optimized = {} %}
     {% set _ = optimized.update(definition) %}
     {% for name, column in definition['columns'].items() %}
@@ -25,16 +28,27 @@
 
         {% if recommended_encoding['encoding'] != column['encoding'] %}
             {{ log("    Changing " ~ name ~ ": " ~ column['encoding'] ~ " -> " ~ recommended_encoding['encoding'] ~ " (" ~ recommended_encoding['reduction_pct'] ~ "%)") }}
+            {% set _ = updated_encodings.update({column['name']: recommended_encoding['encoding']}) %}
         {% else %}
             {{ log("Not Changing " ~ name ~ ": " ~ column['encoding']) }}
         {% endif %}
 
         {% set _ = optimized['columns'][name].update({"encoding": recommended_encoding['encoding']}) %}
+
     {% endfor %}
 
-    {{ return(optimized) }}
+    {{ return((optimized, updated_encodings)) }}
 
 {%- endmacro %}
+
+{%- macro alter_column_encoding(schema, table, updated_encodings) -%}
+  
+  {% for column_name, encoding in updated_encodings.items() %}
+      alter table {{ schema }}.{{ table }} alter {{ column_name }} encode {{ encoding }}; 
+  {% endfor %}
+  commit;
+
+{% endmacro %}
 
 {%- macro insert_into_sql(from_schema, from_table, to_schema, to_table) -%}
 
@@ -59,9 +73,9 @@
 
 {%- endmacro -%}
 
-{%- macro compress_table(schema, table, drop_backup=False,
-                         comprows=none, sort_style=none, sort_keys=none,
-                         dist_style=none, dist_key=none) -%}
+{%- macro compress_table(schema, table, in_place=False, 
+                         drop_backup=False, comprows=none, sort_style=none, 
+                         sort_keys=none, dist_style=none, dist_key=none) -%}
 
   {% if not execute %}
     {{ return(none) }}
@@ -74,20 +88,28 @@
     {{ return(none) }}
   {% endif %}
 
-  {% set optimized = redshift.build_optimized_definition(definition, recommendation) %}
+  {% set optimized, updated_encodings = redshift.build_optimized_definition(definition, recommendation) %}
 
-  {% set _ = optimized.update({"keys": optimized.get('keys', {}) | default({})}) %}
-  {% if sort_style %} {% set _ = optimized['keys'].update({"sort_style": sort_style}) %} {% endif %}
-  {% if sort_keys %}  {% set _ = optimized['keys'].update({"sort_keys": sort_keys}) %} {% endif %}
-  {% if dist_style %} {% set _ = optimized['keys'].update({"dist_style": dist_style}) %} {% endif %}
-  {% if dist_key %}   {% set _ = optimized['keys'].update({"dist_key": dist_key}) %} {% endif %}
+  {% if in_place %}
+      -- only alter the column encodings if at least one column will change to avoid returning an empty query
+      {% if updated_encodings %}
+        {{ redshift.alter_column_encoding(schema, table, updated_encodings) }}
+      {% endif %}
+  {% else %}
+    {% set _ = optimized.update({"keys": optimized.get('keys', {}) | default({})}) %}
 
-  {% set new_table = table ~ "__compressed" %}
-  {% set _ = optimized.update({'name': new_table}) %}
+    {% if sort_style %} {% set _ = optimized['keys'].update({"sort_style": sort_style}) %} {% endif %}
+    {% if sort_keys %}  {% set _ = optimized['keys'].update({"sort_keys": sort_keys}) %} {% endif %}
+    {% if dist_style %} {% set _ = optimized['keys'].update({"dist_style": dist_style}) %} {% endif %}
+    {% if dist_key %}   {% set _ = optimized['keys'].update({"dist_key": dist_key}) %} {% endif %}
 
-  {# Build the DDL #}
-  {{ redshift.build_ddl_sql(optimized) }}
-  {{ redshift.insert_into_sql(schema, table, schema, new_table) }}
-  {{ redshift.atomic_swap_sql(schema, table, new_table, drop_backup) }}
+    {% set new_table = table ~ "__compressed" %}
+    {% set _ = optimized.update({'name': new_table}) %}
+
+    {# Build the DDL #}
+    {{ redshift.build_ddl_sql(optimized) }}
+    {{ redshift.insert_into_sql(schema, table, schema, new_table) }}
+    {{ redshift.atomic_swap_sql(schema, table, new_table, drop_backup) }}
+  {% endif %}
 
 {%- endmacro %}


### PR DESCRIPTION
## Description & motivation
Back in 2020, Redshift introduced support for modifying column compression encodings in-place (some details [here](https://aws.amazon.com/about-aws/whats-new/2020/10/amazon-redshift-supports-modifying-column-comprression-encodings-to-optimize-storage-utilization-query-performance/) & official documentation [here](https://docs.aws.amazon.com/redshift/latest/dg/r_ALTER_TABLE.html)), which can be preferable to the older mechanism of recreating the table with the optimal encodings from a deep copy in certain cases. 

For the past 2.5ish years at Lattice, my team has been using this modified version of the compress_table macro to leverage this "new" Redshift feature (credit to @neddonaldson!).

Changes:
- add an optional `in_place` argument to `compress_table` that defaults to the existing deep copy behavior
- track which columns will need to be re-encoded during `build_optimized_definition`, returning the optimized definition (no change) _and_ an `updated_encodings` column name: encoding dict
- introduce a `alter_column_encodings` helper to modify column encodings w/ an `ALTER {{ table }} ALTER {{ column }}` statement when `in_place=True` and at least one encoding is due to change

Example logs from `build_optimized_definition` & `alter_column_encodings`:
```
[...]
17:02:40.038226 [debug] [Thread-1  ]: SQL status: SELECT in 0 seconds
17:02:40.043104 [debug] [Thread-1  ]:     Changing event_id: lzo -> zstd (40.81%)
17:02:40.043394 [debug] [Thread-1  ]:     Changing event_source: lzo -> zstd (48.28%)
17:02:40.043550 [debug] [Thread-1  ]:     Changing next_event_at: az64 -> zstd (25.99%)
17:02:40.043691 [debug] [Thread-1  ]:     Changing event_sequence_number: az64 -> zstd (14.97%)
17:02:40.043829 [debug] [Thread-1  ]:     Changing source_sequence_number: az64 -> zstd (24.38%)
17:02:40.043965 [debug] [Thread-1  ]:     Changing next_page: lzo -> zstd (39.10%)
17:02:40.044099 [debug] [Thread-1  ]:     Changing next_page_at: az64 -> raw (0.00%)
17:02:40.044234 [debug] [Thread-1  ]:     Changing page_dwell_time_seconds: az64 -> zstd (7.43%)
17:02:40.044364 [debug] [Thread-1  ]: Not Changing final_page_in_session: raw
17:02:40.044499 [debug] [Thread-1  ]:     Changing product_page: lzo -> raw (0.00%)
17:02:40.044631 [debug] [Thread-1  ]:     Changing last_updated_at: az64 -> zstd (81.95%)
17:02:40.047105 [debug] [Thread-1  ]: Using redshift connection "model.lattice_dwh.model"
17:02:40.047358 [debug] [Thread-1  ]: On model.lattice_dwh.model: /* {"app": "dbt", "dbt_version": "1.4.6", "profile_name": "lattice_dwh", "target_name": "dev", "node_id": "model.lattice_dwh.model"} */

        -- only alter the column encodings if at least one column will change to avoid returning an empty query
      
        
      ALTER TABLE dbt_jbuzzelli.model ALTER event_id encode zstd; 
  
      ALTER TABLE dbt_jbuzzelli.model ALTER event_source encode zstd; 
  
      ALTER TABLE dbt_jbuzzelli.model ALTER next_event_at encode zstd; 
  
      ALTER TABLE dbt_jbuzzelli.model ALTER event_sequence_number encode zstd; 
  
      ALTER TABLE dbt_jbuzzelli.model ALTER source_sequence_number encode zstd; 
  
      ALTER TABLE dbt_jbuzzelli.model ALTER next_page encode zstd; 
  
      ALTER TABLE dbt_jbuzzelli.model ALTER next_page_at encode raw; 
  
      ALTER TABLE dbt_jbuzzelli.model ALTER page_dwell_time_seconds encode zstd; 
  
      ALTER TABLE dbt_jbuzzelli.model ALTER product_page encode raw; 
  
      ALTER TABLE dbt_jbuzzelli.model ALTER last_updated_at encode zstd; 
       
17:02:51.209146 [debug] [Thread-1  ]: SQL status: COMMIT in 11 seconds
[...]
```

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)