### PR TITLE
unload_table: add include_partition option to include partition columns when doing unloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Macro signature:
                 cleanpath=Boolean,
                 parallel=Boolean,
                 partition_by=none|List<String>,
+                include_partition=Boolean,
                 extension=None|String
 ) }}
 ```

--- a/macros/unload.sql
+++ b/macros/unload.sql
@@ -50,6 +50,7 @@ where option is
                 cleanpath=False,
                 parallel=False,
                 partition_by=None,
+                include_partition=False,
                 extension=None
                 ) %}
 
@@ -108,6 +109,9 @@ where option is
   {% endif %}
   {% if partition_by %}
   PARTITION BY ( {{ partition_by | join(', ') }} )
+    {% if include_partition %}
+    INCLUDE
+    {% endif %}
   {% endif %}
   {% if extension %}
   EXTENSION '{{ extension }}'


### PR DESCRIPTION
Unload command in Redshift supports an INCLUDE option, which has not been supported by this macro.

This change is aimed toward supporting this functionality.

The INCLUDE keyword will only work if the partition_by option has been set.

## Description & motivation
Unload command in Redshift supports an INCLUDE option, which has not been supported by this macro.

This change is aimed toward supporting this functionality.

Changes:

* add an optional include_partition argument to unload_table defaulting to False to force inclusion of partition columns in unloaded files

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)